### PR TITLE
Implement automatic time-ordering of coordinates

### DIFF
--- a/R/dagify.R
+++ b/R/dagify.R
@@ -95,10 +95,24 @@ dagify <- function(..., exposure = NULL, outcome = NULL, latent = NULL, labels =
       dagitty::coordinates(dgty) <- coords2list(coords)
     } else if (is.list(coords)) {
       dagitty::coordinates(dgty) <- coords
+    } else if (is.function(coords)) {
+      dagitty::coordinates(dgty) <- coords2list(coords(edges2df(dgty)))
     } else {
-      stop("`coords` must be of class `list` or `data.frame`")
+      stop("`coords` must be of class `list`, `data.frame`, or `function`")
     }
   }
   if (!is.null(labels)) label(dgty) <- labels
   dgty
+}
+
+edges2df <- function(.dag) {
+  .edges <- dagitty::edges(.dag)
+  no_outgoing_edges <- unique(.edges$w[!(.edges$w %in% .edges$v)])
+  dplyr::bind_rows(
+    .edges,
+    data.frame(
+      v = no_outgoing_edges,
+      w = rep(NA, length(no_outgoing_edges))
+    )
+  )
 }

--- a/R/layouts.R
+++ b/R/layouts.R
@@ -1,10 +1,12 @@
 #' Create a time-ordered coordinate data frame
 #'
 #' `time_ordered_coords()` is a helper function to create time-ordered DAGs.
-#' Pass the results to the `coords` argument of `dagify()`. The default is to
-#' assume you want variables to go from left to right in order by time.
-#' Variables are spread along the y-axis using a simple algorithm to stack them.
-#' You can also work along the y-axis by setting `direction = "y"`.
+#' Pass the results to the `coords` argument of `dagify()`. If `.vars` if not
+#' specified, these coordinates will be determined automatically. If you want to
+#' be specific, you can also use a list or data frame. The default is to assume
+#' you want variables to go from left to right in order by time. Variables are
+#' spread along the y-axis using a simple algorithm to stack them. You can also
+#' work along the y-axis by setting `direction = "y"`.
 #'
 #' @param .vars A list of character vectors, where each vector represents a
 #'   single time period. Alternatively, a data frame where the first column is
@@ -13,10 +15,17 @@
 #'   a sequence from 1 to the number of variables.
 #' @param direction A character string indicating the axis along which the
 #'   variables should be time-ordered. Either "x" or "y". Default is "x".
+#' @param auto_sort_direction If `.vars` is `NULL`: nodes will be placed as far
+#'   `"left"` or `"right"` of in the graph as is reasonable. Default is right,
+#'   meaning the nodes will be as close as possible in time to their
+#'   descendants.
 #'
 #' @return A tibble with three columns: `name`, `x`, and `y`.
 #'
 #' @examples
+#'
+#'
+#'
 #' coords <- time_ordered_coords(list(
 #'   # time point 1
 #'   "a",
@@ -51,12 +60,12 @@
 #'
 #' @export
 #' @seealso [dagify()], [coords2df()], [coords2list()]
-time_ordered_coords <- function(.vars = NULL, time_points = NULL, direction = c("x", "y")) {
+time_ordered_coords <- function(.vars = NULL, time_points = NULL, direction = c("x", "y"), auto_sort_direction = c("right", "left")) {
   direction <- match.arg(direction)
 
   if (is.null(.vars)) {
     auto_time_ordered_coords <- function(.df) {
-      .df <- auto_time_order(.df)
+      .df <- auto_time_order(.df, sort_direction = auto_sort_direction)
       time_ordered_coords(.df, direction = direction)
     }
 
@@ -103,7 +112,10 @@ calculate_spread <- function(n) {
   spread
 }
 
-auto_time_order <- function(graph) {
+auto_time_order <- function(graph, sort_direction = c("right", "left")) {
+  sort_direction <- match.arg(sort_direction)
+  names(graph)[1:2] <- c("name", "to")
+  graph2 <- graph
   orders <- dplyr::tibble(name = character(), order = integer())
 
   order_value <- 1
@@ -128,8 +140,26 @@ auto_time_order <- function(graph) {
     dplyr::select(name, order) %>%
     dplyr::distinct()
 
-  final_result
+  if (sort_direction == "left") {
+    return(final_result)
+  }
+
+  final_result %>%
+    ggdag_left_join(graph2, by = "name") %>%
+    dplyr::group_by(name) %>%
+    dplyr::group_modify(~ right_sort_coords(.x, final_result)) %>%
+    dplyr::ungroup()
 }
 
+right_sort_coords <- function(.x, .orders) {
+  coords <- .orders %>%
+    dplyr::filter(name %in% .x$to) %>%
+    dplyr::pull(order)
 
+  if (length(coords) == 0) {
+    dplyr::tibble(order = .x$order)
+  } else {
+    dplyr::tibble(order = min(coords) - 1)
+  }
+}
 

--- a/R/layouts.R
+++ b/R/layouts.R
@@ -24,7 +24,13 @@
 #'
 #' @examples
 #'
-#'
+#' dagify(
+#'   d ~ c1 + c2 + c3,
+#'   c1 ~ b1 + b2,
+#'   c3 ~ a,
+#'   b1 ~ a,
+#'   coords = time_ordered_coords()
+#' ) %>% ggdag()
 #'
 #' coords <- time_ordered_coords(list(
 #'   # time point 1

--- a/man/equivalent.Rd
+++ b/man/equivalent.Rd
@@ -48,7 +48,9 @@ ggdag_equivalent_class(
 
 \item{n}{maximal number of returned graphs.}
 
-\item{layout}{a layout available in \code{ggraph}. See \code{\link[ggraph:ggraph]{ggraph::create_layout()}} for details.}
+\item{layout}{a layout available in \code{ggraph}. See \code{\link[ggraph:ggraph]{ggraph::create_layout()}}
+for details. Alternatively, \code{"time_ordered"} will use
+\code{time_ordered_coords()} to algorithmically sort the graph by time.}
 
 \item{...}{optional arguments passed to \code{ggraph::create_layout()}}
 

--- a/man/tidy_dagitty.Rd
+++ b/man/tidy_dagitty.Rd
@@ -11,7 +11,9 @@ tidy_dagitty(.dagitty, seed = NULL, layout = "nicely", ...)
 
 \item{seed}{a numeric seed for reproducible layout generation}
 
-\item{layout}{a layout available in \code{ggraph}. See \code{\link[ggraph:ggraph]{ggraph::create_layout()}} for details.}
+\item{layout}{a layout available in \code{ggraph}. See \code{\link[ggraph:ggraph]{ggraph::create_layout()}}
+for details. Alternatively, \code{"time_ordered"} will use
+\code{time_ordered_coords()} to algorithmically sort the graph by time.}
 
 \item{...}{optional arguments passed to \code{ggraph::create_layout()}}
 }

--- a/man/time_ordered_coords.Rd
+++ b/man/time_ordered_coords.Rd
@@ -4,7 +4,12 @@
 \alias{time_ordered_coords}
 \title{Create a time-ordered coordinate data frame}
 \usage{
-time_ordered_coords(.vars, time_points = NULL, direction = c("x", "y"))
+time_ordered_coords(
+  .vars = NULL,
+  time_points = NULL,
+  direction = c("x", "y"),
+  auto_sort_direction = c("right", "left")
+)
 }
 \arguments{
 \item{.vars}{A list of character vectors, where each vector represents a
@@ -16,18 +21,28 @@ a sequence from 1 to the number of variables.}
 
 \item{direction}{A character string indicating the axis along which the
 variables should be time-ordered. Either "x" or "y". Default is "x".}
+
+\item{auto_sort_direction}{If \code{.vars} is \code{NULL}: nodes will be placed as far
+\code{"left"} or \code{"right"} of in the graph as is reasonable. Default is right,
+meaning the nodes will be as close as possible in time to their
+descendants.}
 }
 \value{
 A tibble with three columns: \code{name}, \code{x}, and \code{y}.
 }
 \description{
 \code{time_ordered_coords()} is a helper function to create time-ordered DAGs.
-Pass the results to the \code{coords} argument of \code{dagify()}. The default is to
-assume you want variables to go from left to right in order by time.
-Variables are spread along the y-axis using a simple algorithm to stack them.
-You can also work along the y-axis by setting \code{direction = "y"}.
+Pass the results to the \code{coords} argument of \code{dagify()}. If \code{.vars} if not
+specified, these coordinates will be determined automatically. If you want to
+be specific, you can also use a list or data frame. The default is to assume
+you want variables to go from left to right in order by time. Variables are
+spread along the y-axis using a simple algorithm to stack them. You can also
+work along the y-axis by setting \code{direction = "y"}.
 }
 \examples{
+
+
+
 coords <- time_ordered_coords(list(
   # time point 1
   "a",

--- a/man/time_ordered_coords.Rd
+++ b/man/time_ordered_coords.Rd
@@ -41,7 +41,13 @@ work along the y-axis by setting \code{direction = "y"}.
 }
 \examples{
 
-
+dagify(
+  d ~ c1 + c2 + c3,
+  c1 ~ b1 + b2,
+  c3 ~ a,
+  b1 ~ a,
+  coords = time_ordered_coords()
+) \%>\% ggdag()
 
 coords <- time_ordered_coords(list(
   # time point 1

--- a/tests/testthat/test-layouts.R
+++ b/tests/testthat/test-layouts.R
@@ -10,13 +10,42 @@ test_that("time ordered layout works", {
     "d"
   ))
 
-  p1 <- dagify(
+  d1 <- dagify(
     d ~ c1 + c2 + c3,
     c1 ~ b1 + b2,
     c3 ~ a,
     b1 ~ a,
     coords = coords
-  ) %>% ggdag()
+  )
+
+  p1 <- ggdag(d1)
+
+  auto_coords_coords <- dagify(
+    d ~ c1 + c2 + c3,
+    c1 ~ b1 + b2,
+    c3 ~ a,
+    b1 ~ a,
+    coords = time_ordered_coords()
+  )
+
+  # auto time ordering is the same
+  expect_equal(
+    coords2list(coords),
+    dagitty::coordinates(auto_coords_coords)
+  )
+
+  auto_coords_layout <- dagify(
+    d ~ c1 + c2 + c3,
+    c1 ~ b1 + b2,
+    c3 ~ a,
+    b1 ~ a
+  )
+
+  # specifying in dagify or tidy_dagitty is the same
+  expect_equal(
+    tidy_dagitty(auto_coords_layout, layout = "time_ordered")$data,
+    tidy_dagitty(auto_coords_coords)$data
+  )
 
   # or use a data frame
   x <- data.frame(


### PR DESCRIPTION
This PR expands `time_ordered_coords()` to be able to create time-ordered coordinates automatically, e.g.

``` r
library(ggdag)
dagify(
  z3 ~ y,
  y ~ x1 + x2,
  a ~ z1 + z2 + z3,
  coords = time_ordered_coords()
) %>% ggdag()
```

![](https://i.imgur.com/ZtUilXX.png)<!-- -->

<sup>Created on 2023-08-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

You can also delay this step to `tidy_dagitty()` and specify `"time_ordered"` as the layout