### PR TITLE
Remove `ScalesListQuiet`

### DIFF
--- a/R/StatsandGeoms.R
+++ b/R/StatsandGeoms.R
@@ -184,55 +184,27 @@ GeomDAGEdgePath <- ggplot2::ggproto("GeomDAGEdgePath", ggraph::GeomEdgePath,
 )
 
 
-
-
-scales_list_quiet <- function() {
-  ggplot2::ggproto(NULL, ScalesListQuiet)
+silence_scales <- function(plot) {
+  old_scales <- plot$scales
+  plot$scales <- ggproto(
+    "ScalesListQuiet", old_scales,
+    add = silent_add
+  )
+  plot
 }
 
-ScalesListQuiet <- ggplot2::ggproto("ScalesListQuiet", NULL,
-  scales = NULL,
-  find = function(self, aesthetic) {
-    vapply(self$scales, function(x) any(aesthetic %in% x$aesthetics), logical(1))
-  },
-  has_scale = function(self, aesthetic) {
-    any(self$find(aesthetic))
-  },
-  add = function(self, scale) {
-    if (is.null(scale)) {
-      return()
-    }
-
-    prev_aes <- self$find(scale$aesthetics)
-    if (any(prev_aes)) {
-      # Get only the first aesthetic name in the returned vector -- it can
-      # sometimes be c("x", "xmin", "xmax", ....)
-      scalename <- self$scales[prev_aes][[1]]$aesthetics[1]
-    }
-
-    # Remove old scale for this aesthetic (if it exists)
-    self$scales <- c(self$scales[!prev_aes], list(scale))
-  },
-  n = function(self) {
-    length(self$scales)
-  },
-  input = function(self) {
-    unlist(lapply(self$scales, "[[", "aesthetics"))
-  },
-
-  # This actually makes a descendant of self, which is functionally the same
-  # as a actually clone for most purposes.
-  clone = function(self) {
-    ggproto(NULL, self, scales = lapply(self$scales, function(s) s$clone()))
-  },
-  non_position_scales = function(self) {
-    ggproto(NULL, self, scales = self$scales[!self$find("x") & !self$find("y")])
-  },
-  get_scales = function(self, output) {
-    scale <- self$scales[self$find(output)]
-    if (length(scale) == 0) {
-      return()
-    }
-    scale[[1]]
+silent_add <- function(self, scale) {
+  if (is.null(scale)) {
+    return()
   }
-)
+
+  prev_aes <- self$find(scale$aesthetics)
+  if (any(prev_aes)) {
+    # Get only the first aesthetic name in the returned vector -- it can
+    # sometimes be c("x", "xmin", "xmax", ....)
+    scalename <- self$scales[prev_aes][[1]]$aesthetics[1]
+  }
+
+  # Remove old scale for this aesthetic (if it exists)
+  self$scales <- c(self$scales[!prev_aes], list(scale))
+}

--- a/R/geom_dag.R
+++ b/R/geom_dag.R
@@ -786,7 +786,7 @@ geom_dag_collider_edges <- function(mapping = NULL, data = NULL,
 ggplot.tidy_dagitty <- function(data = NULL, mapping = aes(), ...) {
   p <- ggplot2::ggplot(fortify(data), mapping = mapping, ...)
 
-  p$scales <- scales_list_quiet()
+  p <- silence_scales(p)
 
   p + expand_plot(
     expand_x = expansion(c(.10, .10)),

--- a/tests/testthat/_snaps/StatsandGeoms.md
+++ b/tests/testthat/_snaps/StatsandGeoms.md
@@ -1,0 +1,18 @@
+# We do not need to update `silent_add()`.
+
+    Code
+      body
+    Output
+      {
+          if (is.null(scale)) {
+              return()
+          }
+          prev_aes <- self$find(scale$aesthetics)
+          if (any(prev_aes)) {
+              scalename <- self$scales[prev_aes][[1]]$aesthetics[1]
+              cli::cli_inform(c("Scale for {.field {scalename}} is already present.", 
+                  "Adding another scale for {.field {scalename}}, which will replace the existing scale."))
+          }
+          self$scales <- c(self$scales[!prev_aes], list(scale))
+      }
+

--- a/tests/testthat/test-StatsandGeoms.R
+++ b/tests/testthat/test-StatsandGeoms.R
@@ -13,5 +13,13 @@ test_that("Geom and Stat ggprotos are in fact ggprotos", {
   expect_ggproto(StatEdgeDiagonal)
   expect_ggproto(StatEdgeFan)
   expect_ggproto(GeomDAGEdgePath)
-  expect_ggproto(ScalesListQuiet)
+})
+
+test_that("We do not need to update `silent_add()`.", {
+  # This is a sentinel test to see if upstream ggplot2 has made changes to
+  # the ggplot2:::Scales$add() method.
+  # If this test fails, the add method has likely changed and `silent_add()`
+  # may need to be updated in StatsandGeoms.R.
+  body <- body(environment(ggplot()$scales$add)$f)
+  expect_snapshot(body)
 })


### PR DESCRIPTION
TL;DR: This PR aims to fix compatibility with the new ggplot2 version.

Hi Malcolm,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break ggdag. Given that other packages also import ggdag, we felt it was prudent to help out to transition to the new version.

The culprit of the breakage was the `ScalesListQuiet` class, which (to my best estimate) re-implements `ggplot2:::ScalesList` with minor modifications. We made internal changes to `ggplot2:::ScalesList`, see https://github.com/tidyverse/ggplot2/pull/5144. However, as these changes aren't automatically transferred, ggdag would break.

This PR replaces the `ScalesListQuiet` class with a function that adds the custom `ScalesListQuiet$add()` method on the go. This should make ggdag immune to most\* changes in the `ggplot2:::ScalesList` class, and works both with the CRAN version and release candidate of ggplot2.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled at the end of January / early Februari. The progress can be tracked in https://github.com/tidyverse/ggplot2/issues/5588.
We are hoping that this PR might help ggside be ready around that time to soften the impact on downstream packages.

\* I've added a 'canary in the coal mine'-test for modifications to `ggplot2:::ScalesList$add()`.