### PR TITLE
Provide helper for testing dag data equivalence

### DIFF
--- a/tests/testthat/helper-dag.R
+++ b/tests/testthat/helper-dag.R
@@ -1,0 +1,17 @@
+expect_equal_dag <- function(object, expected, ...) {
+  object_graph <- attr(object, "graph")
+  attr(object, "graph") <- NULL
+  expected_graph <- attr(expected, "graph")
+  attr(expected, "graph") <- NULL
+  expect_equal(object, expected, ...)
+  expect_equal(
+    tidygraph::as_tibble(object_graph, "nodes"),
+    tidygraph::as_tibble(expected_graph, "nodes"),
+    ...
+  )
+  expect_equal(
+    tidygraph::as_tibble(object_graph, "edges"),
+    tidygraph::as_tibble(expected_graph, "edges"),
+    ...
+  )
+}

--- a/tests/testthat/test-layouts.R
+++ b/tests/testthat/test-layouts.R
@@ -42,7 +42,7 @@ test_that("time ordered layout works", {
   )
 
   # specifying in dagify or tidy_dagitty is the same
-  expect_equal(
+  expect_equal_dag(
     tidy_dagitty(auto_coords_layout, layout = "time_ordered") %>% pull_dag_data(),
     tidy_dagitty(auto_coords_coords) %>% pull_dag_data()
   )

--- a/tests/testthat/test-pull.R
+++ b/tests/testthat/test-pull.R
@@ -12,7 +12,7 @@ test_that("pull_dag and pull_dag_data return the correct objects", {
   expect_equal(pull_dag(tidy_dag), dag)
 
   # Test that pull_dag_data returns the correct data frame
-  expect_equal(pull_dag_data(dag, seed = 1234), pull_dag_data(tidy_dag))
+  expect_equal_dag(pull_dag_data(dag, seed = 1234), pull_dag_data(tidy_dag))
 
   # Test that pull_dag_data returns the correct data frame from a tidy_dagitty object
   expect_equal(pull_dag_data(tidy_dag), pull_dag_data(tidy_dag))

--- a/tests/testthat/test-tidy_dag.R
+++ b/tests/testthat/test-tidy_dag.R
@@ -55,7 +55,8 @@ test_that("`as_tidy_dagitty()` returns correct objects", {
   .dag <- dagify(y ~ x + z, x ~ z)
   v1_dag <- tidy_dagitty(.dag, seed = 1234)
   v2_dag <- as_tidy_dagitty(.dag, seed = 1234)
-  expect_equal(v1_dag, v2_dag)
+  expect_equal(v1_dag$dag, v2_dag$dag)
+  expect_equal_dag(v1_dag$data, v2_dag$data)
 })
 
 test_that("`as_tidy_dagitty()` works with other configurations", {


### PR DESCRIPTION
This PR fixes #143. Briefly it avoids testing the objects directly due to the complicated nature of how igraph objects are stored. Instead it extracts all descriptive data from the object and tests these for equivalence